### PR TITLE
Revert "alloca" implementation

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -28,7 +28,6 @@ With following modifications in `quickjs` folder:
     1. header file including
     2. A lot of binding functions are removed
     3. Macros for other platforms
-    4. Replace `alloca` function
 
 3. The following files are removed from original QuickJS:
     - quickjs-libc.c

--- a/include/c-stdlib/my_stdlib.h
+++ b/include/c-stdlib/my_stdlib.h
@@ -9,5 +9,6 @@ int atoi(const char *);
 int abs(int);
 void exit(int);
 void abort(void);
+#define alloca __builtin_alloca
 
 #endif /* C_STDLIB_STDLIB_H_ */

--- a/quickjs/libregexp.c
+++ b/quickjs/libregexp.c
@@ -2531,8 +2531,7 @@ int lre_exec(uint8_t **capture,
     for(i = 0; i < s->capture_count * 2; i++)
         capture[i] = NULL;
     alloca_size = s->stack_size_max * sizeof(stack_buf[0]);
-    uint8_t temp[alloca_size];
-    stack_buf = (StackInt *)temp;
+    stack_buf = alloca(alloca_size);
     ret = lre_exec_backtrack(s, capture, stack_buf, 0, bc_buf + RE_HEADER_LEN,
                              cbuf + (cindex << cbuf_type), FALSE);
     lre_realloc(s->opaque, s->state_stack, 0);

--- a/quickjs/quickjs.c
+++ b/quickjs/quickjs.c
@@ -5094,11 +5094,10 @@ static JSValue js_c_function_data_call(JSContext *ctx, JSValueConst func_obj,
     JSCFunctionDataRecord *s = JS_GetOpaque(func_obj, JS_CLASS_C_FUNCTION_DATA);
     JSValueConst *arg_buf;
     int i;
-    uint8_t temp[sizeof(arg_buf[0]) * s->length];
 
     /* XXX: could add the function on the stack for debug */
     if (unlikely(argc < s->length)) {
-        arg_buf = (JSValueConst *)temp;
+        arg_buf = alloca(sizeof(arg_buf[0]) * s->length);
         for(i = 0; i < argc; i++)
             arg_buf[i] = argv[i];
         for(i = argc; i < s->length; i++)
@@ -16043,11 +16042,10 @@ static JSValue js_call_c_function(JSContext *ctx, JSValueConst func_obj,
     sf->cur_func = (JSValue)func_obj;
     sf->arg_count = argc;
     arg_buf = argv;
-    uint8_t temp[sizeof(arg_buf[0]) * arg_count];
 
     if (unlikely(argc < arg_count)) {
         /* ensure that at least argc_count arguments are readable */
-        arg_buf = (JSValueConst *)temp;
+        arg_buf = alloca(sizeof(arg_buf[0]) * arg_count);
         for(i = 0; i < argc; i++)
             arg_buf[i] = argv[i];
         for(i = argc; i < arg_count; i++)
@@ -16158,8 +16156,7 @@ static JSValue js_call_bound_function(JSContext *ctx, JSValueConst func_obj,
     arg_count = bf->argc + argc;
     if (js_check_stack_overflow(ctx->rt, sizeof(JSValue) * arg_count))
         return JS_ThrowStackOverflow(ctx);
-    uint8_t temp[sizeof(JSValue) * arg_count];
-    arg_buf = (JSValueConst *)temp;
+    arg_buf = alloca(sizeof(JSValue) * arg_count);
     for(i = 0; i < bf->argc; i++) {
         arg_buf[i] = bf->argv[i];
     }
@@ -16290,9 +16287,7 @@ static JSValue JS_CallInternal(JSContext *caller_ctx, JSValueConst func_obj,
     init_list_head(&sf->var_ref_list);
     var_refs = p->u.func.var_refs;
 
-    // TODO: fix it
-    uint8_t temp[1024*10];
-    local_buf = (JSValue *)temp;
+    local_buf = alloca(alloca_size);
     if (unlikely(arg_allocated_size)) {
         int n = min_int(argc, b->arg_count);
         arg_buf = local_buf;

--- a/tests/ckb_js_tests/test_data/fs_module/main.js
+++ b/tests/ckb_js_tests/test_data/fs_module/main.js
@@ -3,4 +3,4 @@
 import { fib } from "./fib_module.js";
 
 console.log("Hello World");
-console.log("fib(10)=", fib(10));
+console.log(`fib(10)=${fib(10)}`);

--- a/tests/ckb_js_tests/test_data/fs_module_mount/main.js
+++ b/tests/ckb_js_tests/test_data/fs_module_mount/main.js
@@ -4,7 +4,7 @@ ckb.mount(2, ckb.SOURCE_CELL_DEP)
 
 import('./fib_module.js')
     .then((module) => {
-        console.log("fib(10)=", module.fib(10))
+        console.log(`fib(10)=${module.fib(10)}`)
     })
     .catch((err) => {
         console.log(err)


### PR DESCRIPTION
alloca can be implemented directly by "__builtin_alloca". Workaround is removed.

