### PR TITLE
Reduce the size of the executable file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
       with:
         submodules: recursive
     - name: Install LLVM and Clang
-      run: brew install llvm@18
+      run: |
+        brew install coreutils
+        brew install llvm@18
     - name: Build
       run: export PATH="/opt/homebrew/opt/llvm/bin:$PATH" && make all

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ ifeq ($(UNAME), Darwin)
 endif
 
 CFLAGS := --target=riscv64 -march=rv64imc_zba_zbb_zbc_zbs
-CFLAGS += -g -Os \
-		-Wall -Werror -Wno-nonnull -Wno-unused-function \
-		-nostdinc -nostdlib \
-		-fdata-sections -ffunction-sections
+CFLAGS += -g -Oz \
+          -Wall -Werror -Wno-nonnull -Wno-unused-function \
+          -nostdinc -nostdlib \
+          -fdata-sections -ffunction-sections
 
 CFLAGS += -I deps/ckb-c-stdlib
 CFLAGS += -I include -I include/c-stdlib

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,8 @@ clean:
 	rm -f build/ckb-js-vm
 	rm -f build/ckb-js-vm.debug
 	cd tests/ckb_js_tests && make clean
-	make -C deps/compiler-rt-builtins-riscv clean
+	cd deps/compiler-rt-builtins-riscv && make clean
+	cd deps/musl && rm -rf obj release
 
 STYLE := "{BasedOnStyle: Google, TabWidth: 4, IndentWidth: 4, UseTab: Never, SortIncludes: false, ColumnLimit: 120}"
 


### PR DESCRIPTION
Size: 527K -> 441K
Cycles: 12M -> 13.2M when running `ckb-debugger --read-file /home/ubuntu/src/ckb-js-vm/tests/examples/pi_bigint.js --bin build/ckb-js-vm -- -r` 
