### PR TITLE
chore: better naming for file system

### DIFF
--- a/libc/ckb_cell_fs.h
+++ b/libc/ckb_cell_fs.h
@@ -11,17 +11,17 @@ typedef struct FSEntry {
     FSBlob content;
 } FSEntry;
 
-typedef struct CellFileSystemNode {
+typedef struct FSCellNode {
     uint32_t count;
     FSEntry *files;
     void *start;
     const char *prefix;
-} CellFileSystemNode;
+} FSCellNode;
 
-typedef struct CellFileSystem {
-    CellFileSystemNode *current;
-    struct CellFileSystem *next;
-} CellFileSystem;
+typedef struct FSCell {
+    FSCellNode *current;
+    struct FSCell *next;
+} FSCell;
 
 typedef struct FSFile {
     const char *filename;
@@ -33,14 +33,8 @@ typedef struct FSFile {
     uint8_t rc;
 } FSFile;
 
-int get_file(const CellFileSystem *fs, const char *filename, FSFile **f);
-
 int ckb_get_file(const char *filename, FSFile **file);
-
-int load_fs(CellFileSystem **fs, const char *prefix, void *buf, uint64_t buflen);
-
 int ckb_load_fs(const char *prefix, void *buf, uint64_t buflen);
-
 void ckb_reset_fs();
 
 #endif

--- a/libc/src/ckb_cell_fs.c
+++ b/libc/src/ckb_cell_fs.c
@@ -4,9 +4,9 @@
 
 #include "ckb_cell_fs.h"
 
-static CellFileSystem *CELL_FILE_SYSTEM = NULL;
+static FSCell *CELL_FILE_SYSTEM = NULL;
 
-int get_file(const CellFileSystem *fs, const char *filename, FSFile **f) {
+static int get_file(const FSCell *fs, const char *filename, FSFile **f) {
     if (fs == NULL) {
         return -1;
     }
@@ -14,8 +14,8 @@ int get_file(const CellFileSystem *fs, const char *filename, FSFile **f) {
     if (file == 0) {
         return -1;
     }
-    CellFileSystem *cfs = (CellFileSystem *)fs;
-    CellFileSystemNode *node = cfs->current;
+    FSCell *cfs = (FSCell *)fs;
+    FSCellNode *node = cfs->current;
     while (node != NULL) {
         if (strncmp(node->prefix + 1, filename, strlen(node->prefix) - 1) != 0) {
             if (cfs->next == NULL) {
@@ -53,17 +53,17 @@ int get_file(const CellFileSystem *fs, const char *filename, FSFile **f) {
 
 int ckb_get_file(const char *filename, FSFile **file) { return get_file(CELL_FILE_SYSTEM, filename, file); }
 
-int load_fs(CellFileSystem **fs, const char *prefix, void *buf, uint64_t buflen) {
+static int load_fs(FSCell **fs, const char *prefix, void *buf, uint64_t buflen) {
     if (fs == NULL || buf == NULL) {
         return -1;
     }
 
-    CellFileSystemNode *node = (CellFileSystemNode *)malloc(sizeof(CellFileSystemNode));
+    FSCellNode *node = (FSCellNode *)malloc(sizeof(FSCellNode));
     if (node == NULL) {
         return -1;
     }
 
-    CellFileSystem *newfs = (CellFileSystem *)malloc(sizeof(CellFileSystem));
+    FSCell *newfs = (FSCell *)malloc(sizeof(FSCell));
     if (newfs == NULL) {
         free(node);
         return -1;


### PR DESCRIPTION
All types in file system are started with "FS". The functions are prefixed with "ckb".