### PR TITLE
feat: add qjsc to turn js into bytecode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         node-version: '22'
     - name: Build
       run: make all
+    - name: Build qjsc
+      run: make -f qjsc.mak
     - name: Install tools
       run: make install
     - name: Tests

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -25,6 +25,8 @@ jobs:
       run: make install
     - name: Build
       run: make all
+    - name: Build qjsc
+      run: make -f qjsc.mak
     - name: Install node dependencies
       run: pnpm install
     - name: Build all packages

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ dist/
 
 
 typedoc/
+
+deps/quickjs/qjs
+deps/quickjs/qjsc
+deps/quickjs/run-test262

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -14,10 +14,8 @@
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "scripts": {
-    "start": "ckb-debugger --read-file dist/index.js --bin ../../build/ckb-js-vm -- -r",
-    "build": "tsc --noEmit && esbuild --platform=neutral --minify --bundle --external:@ckb-js-std/bindings --target=es2022 src/index.ts --outfile=dist/index.js",
-    "compile": "ckb-debugger --read-file dist/index.js --bin ../../build/ckb-js-vm -- -c | gawk -f ../../tools/compile.awk | xxd -r -p > dist/index.bc",
-    "start:bc": "ckb-debugger --read-file dist/index.bc --bin ../../build/ckb-js-vm -- -r",
+    "start": "ckb-debugger --read-file dist/index.bc --bin ../../build/ckb-js-vm -- -r",
+    "build": "tsc --noEmit && esbuild --platform=neutral --minify --bundle --external:@ckb-js-std/bindings --target=es2022 src/index.ts --outfile=dist/index.js && ../../build/qjsc/qjsc dist/index.js dist/index.bc",
     "format": "prettier --write .",
     "check:format": "prettier --check .",
     "clean": "rm -f dist/*"

--- a/qjsc.mak
+++ b/qjsc.mak
@@ -1,0 +1,49 @@
+# Compiler settings
+CC = clang-18
+CFLAGS += -Ideps/quickjs
+CFLAGS += -Wall -Wno-array-bounds -Wno-format-truncation -Wno-implicit-const-int-float-conversion -fwrapv
+CFLAGS += -D_GNU_SOURCE -DCONFIG_VERSION=\"2024-01-13\" -DCONFIG_BIGNUM
+CFLAGS += -O2
+CFLAGS += -DCONFIG_LTO -flto
+
+STYLE := "{BasedOnStyle: Google, TabWidth: 4, IndentWidth: 4, UseTab: Never, SortIncludes: false, ColumnLimit: 120}"
+
+# Output directory
+OBJDIR = build/qjsc
+
+# Object files
+OBJS = $(OBJDIR)/qjsc.o \
+       $(OBJDIR)/quickjs.o \
+       $(OBJDIR)/libregexp.o \
+       $(OBJDIR)/libunicode.o \
+       $(OBJDIR)/cutils.o \
+       $(OBJDIR)/quickjs-libc.o \
+       $(OBJDIR)/libbf.o
+
+# Linker flags
+LDFLAGS = -flto
+LIBS = -lm
+
+# Main target
+build/qjsc/qjsc: $(OBJS)
+	$(CC) $(LDFLAGS) -o $@ $(OBJS) $(LIBS)
+
+$(OBJDIR)/qjsc.o: tools/qjsc/qjsc.c
+	@mkdir -p $(OBJDIR)
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+$(OBJDIR)/%.o: deps/quickjs/%.c
+	@mkdir -p $(OBJDIR)
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+# Include dependency files
+-include $(OBJS:.o=.o.d)
+
+fmt:
+	clang-format-18 -i -style=$(STYLE) tools/qjsc/qjsc.c
+
+# Clean target
+clean:
+	rm -rf $(OBJDIR)
+
+.PHONY: clean fmt

--- a/tools/qjsc/qjsc.c
+++ b/tools/qjsc/qjsc.c
@@ -1,0 +1,98 @@
+/**
+ * A simple compiler turning javascript code into bytecode
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <inttypes.h>
+#include <string.h>
+#include <assert.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdbool.h>
+#include "quickjs.h"
+#include "quickjs-libc.h"
+#include "cutils.h"
+
+
+static void output_object_code(JSContext *ctx, FILE *fo, JSValueConst obj, const char *c_name, BOOL load_only) {
+    uint8_t *out_buf;
+    size_t out_buf_len;
+    int flags;
+    flags = JS_WRITE_OBJ_BYTECODE;
+    out_buf = JS_WriteObject(ctx, &out_buf_len, obj, flags);
+    if (!out_buf) {
+        js_std_dump_error(ctx);
+        exit(1);
+    }
+
+    fwrite(out_buf, out_buf_len, 1, fo);
+
+    js_free(ctx, out_buf);
+}
+
+static void compile_file(JSContext *ctx, FILE *fo, const char *filename, const char *c_name1, int module) {
+    uint8_t *buf;
+    int eval_flags;
+    JSValue obj;
+    size_t buf_len;
+
+    buf = js_load_file(ctx, &buf_len, filename);
+    if (!buf) {
+        fprintf(stderr, "Could not load '%s'\n", filename);
+        exit(1);
+    }
+    eval_flags = JS_EVAL_FLAG_COMPILE_ONLY;
+    if (module < 0) {
+        module = (has_suffix(filename, ".mjs") || JS_DetectModule((const char *)buf, buf_len));
+    }
+    if (module)
+        eval_flags |= JS_EVAL_TYPE_MODULE;
+    else
+        eval_flags |= JS_EVAL_TYPE_GLOBAL;
+    obj = JS_Eval(ctx, (const char *)buf, buf_len, filename, eval_flags);
+    if (JS_IsException(obj)) {
+        js_std_dump_error(ctx);
+        exit(1);
+    }
+    js_free(ctx, buf);
+    output_object_code(ctx, fo, obj, filename, false);
+    JS_FreeValue(ctx, obj);
+}
+
+void print_usage(void) {
+    printf("Usage: qjsc <input.js> <output.bin>\n");
+    printf("Compile JavaScript source code to QuickJS bytecode\n\n");
+    printf("Arguments:\n");
+    printf("  <input.js>    Input JavaScript source file\n");
+    printf("  <output.bin>  Output binary bytecode file\n");
+}
+
+static int js_module_dummy_init(JSContext *ctx, JSModuleDef *m) { return 0; }
+
+JSModuleDef *js_module_dummy_loader(JSContext *ctx, const char *module_name, void *opaque) {
+    return JS_NewCModule(ctx, module_name, js_module_dummy_init);
+}
+
+int main(int argc, char **argv) {
+    JSRuntime* rt = JS_NewRuntime();
+    JSContext* ctx = JS_NewContext(rt);
+    JS_AddIntrinsicBigFloat(ctx);
+    JS_AddIntrinsicBigDecimal(ctx);
+    JS_AddIntrinsicOperators(ctx);
+    JS_EnableBignumExt(ctx, true);
+
+    /* loader for ES6 modules */
+    JS_SetModuleLoaderFunc(rt, NULL, js_module_dummy_loader, NULL);
+    if (argc != 3) {
+        print_usage();
+        return 1;
+    }
+
+    const char *filename = argv[1];
+    const char *output = argv[2];
+    FILE *fo = fopen(output, "w");
+    compile_file(ctx, fo, filename, NULL, 1);
+    fclose(fo);
+    return 0;
+}


### PR DESCRIPTION
Previously, we used ckb-debugger to dump bytecode. It is difficult to use.
