### PR TITLE
chore: rename package path

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@ckb-js-std/bindings": "workspace:*"
+    "@ckb-js-std/bindings": "workspace:../bindings"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
   packages/core:
     dependencies:
       '@ckb-js-std/bindings':
-        specifier: workspace:*
+        specifier: workspace:../bindings
         version: link:../bindings
 
   packages/examples:


### PR DESCRIPTION
fix following pnpm issue:
```
❯ pnpm install nervosnetwork/ckb-js-vm#path:/packages/bindings
Already up to date
Progress: resolved 75, reused 75, downloaded 0, added 0, done
Done in 3.3s
❯ pnpm install nervosnetwork/ckb-js-vm#path:/packages/core
 ERR_PNPM_WORKSPACE_PKG_NOT_FOUND  In : "@ckb-js-std/bindings@workspace:*" is in the dependencies but no package named "@ckb-js-std/bindings" is present in the workspace

This error happened while installing the dependencies of @ckb-js-std/core@0.1.0

Packages found in the workspace: 
Progress: resolved 2, reused 3, downloaded 0, added 0
```
