### PR TITLE
chore: publish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,13 @@
     "esbuild": "0.24.2",
     "eslint": "9.18.0",
     "prettier": "3.4.2",
-    "typescript": "^5.7.3",
     "typedoc": "0.27.6",
-    "typedoc-material-theme": "^1.1.0"
+    "typedoc-material-theme": "^1.1.0",
+    "typescript": "^5.7.3"
   },
-  "pnpm": {}
+  "pnpm": {
+    "ignoredBuiltDependencies": [
+      "esbuild"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "pnpm -r run build",
     "format": "pnpm -r run format",
     "check:format": "pnpm -r run check:format",
+    "publish": "pnpm build && pnpm -r run publish",
     "docs": "typedoc"
   },
   "devDependencies": {

--- a/packages/bindings/.npmignore
+++ b/packages/bindings/.npmignore
@@ -1,0 +1,12 @@
+node_modules/
+
+typedoc.json
+tsconfig.json
+tsconfig.*.json
+eslint.config.mjs
+.prettierrc
+.prettierignore
+
+tsconfig.tsbuildinfo
+tsconfig.*.tsbuildinfo
+.github/

--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -10,6 +10,7 @@
     "type": "git",
     "url": "https://github.com/nervosnetwork/ckb-js-vm.git"
   },
+  "type": "module",
   "scripts": {
     "format": "prettier --write .",
     "check:format": "prettier --check ."

--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -1,0 +1,12 @@
+node_modules/
+
+typedoc.json
+tsconfig.json
+tsconfig.*.json
+eslint.config.mjs
+.prettierrc
+.prettierignore
+
+tsconfig.tsbuildinfo
+tsconfig.*.tsbuildinfo
+.github/

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,7 @@
     "type": "git",
     "url": "https://github.com/nervosnetwork/ckb-js-vm.git"
   },
+  "type": "module",
   "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -10,6 +10,7 @@
     "type": "git",
     "url": "https://github.com/nervosnetwork/ckb-js-vm.git"
   },
+  "type": "module",
   "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -4,7 +4,7 @@
   "description": "Write scripts in JavaScript on CKB-VM",
   "author": "CKB-VM Team",
   "license": "MIT",
-  "private": false,
+  "private": true,
   "homepage": "https://github.com/nervosnetwork/ckb-js-vm",
   "repository": {
     "type": "git",


### PR DESCRIPTION
mark examples not publishing